### PR TITLE
リファクタリング

### DIFF
--- a/client/src/App/App.tsx
+++ b/client/src/App/App.tsx
@@ -185,7 +185,6 @@ const Circles: FC<CirclesProps> = ({
     clearInterval(currentCircleIntervalID);
     return null;
   }, []);
-  const func = circleIntervalID === null ? start : stop;
 
   return (
     <>
@@ -216,7 +215,9 @@ const Circles: FC<CirclesProps> = ({
         />
         <p>{intervalMS} [ms]</p>
 
-        <button style={buttonStyle} onClick={() => setCircleIntervalID(func)}>
+        <button style={buttonStyle} onClick={() => {
+          setCircleIntervalID(circleIntervalID === null ? start : stop)
+          }}>
           {circleIntervalID === null ? "start" : "stop"}
         </button>
 

--- a/client/src/App/App.tsx
+++ b/client/src/App/App.tsx
@@ -226,15 +226,13 @@ const Circles: FC<CirclesProps> = ({
         </button>
       </div>
 
-      <div style={{ textAlign: "center" }}>
-        <svg width={width} height={height}>
-          {/* 上はメモしてなくて下はメモされてるはず　メモした方が2-4倍くらい速そう*/}
-          {/*{circles.map(cir => <Circle cir={cir} key={cir.id}/>)}*/}
-          {circles.map((cir) => (
-            <MemoCircle cir={cir} key={cir.id} />
-          ))}
-        </svg>
-      </div>
+      <svg width={width} height={height}>
+        {/* 上はメモしてなくて下はメモされてるはず　メモした方が2-4倍くらい速そう*/}
+        {/*{circles.map(cir => <Circle cir={cir} key={cir.id}/>)}*/}
+        {circles.map((cir) => (
+          <MemoCircle cir={cir} key={cir.id} />
+        ))}
+      </svg>
     </>
   );
 };

--- a/client/src/App/App.tsx
+++ b/client/src/App/App.tsx
@@ -186,7 +186,6 @@ const Circles: FC<CirclesProps> = ({
     return null;
   }, []);
   const func = circleIntervalID === null ? start : stop;
-  const msg = circleIntervalID === null ? "start" : "stop";
 
   return (
     <>
@@ -218,7 +217,7 @@ const Circles: FC<CirclesProps> = ({
         <p>{intervalMS} [ms]</p>
 
         <button style={buttonStyle} onClick={() => setCircleIntervalID(func)}>
-          {msg}
+          {circleIntervalID === null ? "start" : "stop"}
         </button>
 
         <button style={buttonStyle} onClick={() => setCircles(update_circles)}>

--- a/client/src/App/App.tsx
+++ b/client/src/App/App.tsx
@@ -28,22 +28,26 @@ type CirclesProps = {
   colors?: string[];
 };
 
-const buttonStyle = {
-  width: 300,
+const buttonStyle: React.CSSProperties = {
+  minWidth: 280,
+  padding: 20,
   height: 60,
-  margin: "auto",
   borderWidth: 2,
   borderRadius: 15,
   borderColor: "#00a381",
   background: "#eaf4fc",
   textAlign: "center" as "center",
 };
-const seekbarStyle = {
+const seekbarStyle: React.CSSProperties = {
   width: 500,
   height: 8,
-  margin: "auto",
   background: "#000000",
   borderRadius: 10,
+};
+const appStyle: React.CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "center"
 };
 
 const rand_norm = (mean: number, variance: number) =>
@@ -66,8 +70,7 @@ const Graph: FC<{}> = () => {
     <>
       <div
         style={{
-          height: 100,
-          margin: "auto",
+          padding: "40px 0",
           display: "flex",
           justifyContent: "center",
           alignItems: "center",
@@ -90,9 +93,7 @@ const Graph: FC<{}> = () => {
           }}
         />
       </div>
-      <div style={{ width: 1000, margin: "auto" }}>
-        <HighchartsReact highcharts={Highcharts} options={options} />
-      </div>
+      <HighchartsReact highcharts={Highcharts} options={options} />
     </>
   );
 };
@@ -190,7 +191,7 @@ const Circles: FC<CirclesProps> = ({
   return (
     <>
       <div
-        style={{ width: width, height: 90, display: "flex", margin: "auto" }}
+        style={{ width: width, height: 90, display: "flex", justifyContent: "space-around", alignItems: "center" }}
       >
         <input
           style={seekbarStyle}
@@ -214,7 +215,7 @@ const Circles: FC<CirclesProps> = ({
             }
           }}
         />
-        <p style={{ margin: "auto" }}>{intervalMS} [ms]</p>
+        <p>{intervalMS} [ms]</p>
 
         <button style={buttonStyle} onClick={() => setCircleIntervalID(func)}>
           {msg}
@@ -246,8 +247,7 @@ const Paths: FC<{}> = () => {
     <>
       <div
         style={{
-          height: 100,
-          margin: "auto",
+          padding: "40px 0",
           display: "flex",
           justifyContent: "center",
           alignItems: "center",
@@ -300,7 +300,7 @@ const Paths: FC<{}> = () => {
 
 export const App: FC<Props> = () => {
   return (
-    <div>
+    <div style={appStyle}>
       <Graph />
 
       <Circles />


### PR DESCRIPTION
# CSSのリファクタリング

## 変更概要
- Appコンポーネントにflex-boxを適応し、中央揃えになるようにしました。
- それに伴い不要なwidth指定やmargin: autoを削除しました。
- そのため、今の横幅は一番width指定が1番広いコンポーネントが基準になるようになっています(今だとCirclesの1800px)。
- ボタンは幅をwidthで指定するのではなく、min-widthとpaddingで指定するようにしました。
- その他「ここはheightじゃなくてpaddingで指定したほうがいいな」って思ったところはpaddingに書き換えました。

## 変更理由
### Appコンポーネントにflex-boxを適応
今のコードの場合、各コンポーネント単位にmargin: autoを適応して中央揃えを実現してたけど、外側でflex-boxを用いて中央揃えしたほうが簡潔になると考え変更しました。

### ボタンの幅の指定方法を変えた理由
min-widthは横幅の最低値を指定できます。そのため、中の文字が長くてボタンから溢れそうになったら、自動的に横に長くなってくれます。paddingも指定すると横に伸びつつも最低限の余白を確保できます。

### heightからpaddingnに変えた理由
コンポーネントにもよるけど、高さが固定されてしまうheightよりも、中の要素の大きさに合わせて柔軟にサイズが変わるpaddingのほうが良いことが多いです。もちろんheightを絶対使うなって言いたいわけじゃなくて、適材適所的なことを言いたい。